### PR TITLE
Amend some ssh documentation

### DIFF
--- a/intermediate/shell/02-ssh.md
+++ b/intermediate/shell/02-ssh.md
@@ -284,6 +284,19 @@ $ rm id_rsa.pub
 $ exit
 ~~~
 
+Finally, with newer versions of the OpenSSH tool suite, there is one
+command that will do all of this for us: the `ssh-copy-id` command.
+
+~~~
+$ ssh-copy-id -i ~/.ssh/id_rsa.pub remote-host
+jsmith@remote-host's password:
+Now try logging into the machine, with "ssh 'remote-host'", and check in:
+
+.ssh/authorized_keys
+
+to make sure we haven't added extra keys that you weren't expecting.
+~~~
+
 <div class="keypoints" markdown="1">
 
 #### Key Points

--- a/novice/git/05-sshkeys.md
+++ b/novice/git/05-sshkeys.md
@@ -40,9 +40,11 @@ If you don't see `id_rsa.pub`, use the following command to generate a new key p
 
 <div class="in" markdown="1">
 ~~~
-$ ssh-keygen -t rsa -C "your@email.com"
+$ ssh-keygen -o -t rsa -C "your@email.com"
 ~~~
 </div>
+
+(The `-o` option was added in 2014; if this command fails for you, just remove the `-o` and try again)
 
 When asked where to save the new key, hit enter to accept the default location.
 


### PR DESCRIPTION
This is to update the documentation to include using `ssh-copy-id` (for convenience/simplicity) and to use the `-o` option to `ssh-keygen`.

The latter is important as a matter of getting people to use the more secure password encryption option. This should have been made the default behavior for the tool, but it was never updated. As your documentation comes up in the top 20 Google search results for using this tool, it would be a great help for your documentation to use this option.